### PR TITLE
Fixed bug with the scroll set to random positions when there are multiple lists and also made scroll bar visible

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -25,6 +25,8 @@ const App = () => {
     if (!board.boardId) {
       dispatch(setNewBoardState());
     }
+
+    document.getElementById("lists-wrapper").scrollLeft = 0;
   }, []);
 
   const handleDragEnd = (result) => {
@@ -79,7 +81,12 @@ const App = () => {
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="app" type="list" direction="horizontal">
           {(provided) => (
-            <div className="flex px-6 pt-3 list-height scroll-x-hidden" ref={provided.innerRef} {...[provided.droppableProps]}>
+            <div
+              id="lists-wrapper"
+              className="flex px-6 pt-3 lists-wrapper overflow-x-auto"
+              ref={provided.innerRef}
+              {...[provided.droppableProps]}
+            >
               {lists.map((list, index) => (
                 <List key={list.id} list={list} index={index} />
               ))}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -27,9 +27,9 @@
     @apply border-trello-blue-100 border-current;
   }
 
-  .list-height {
-    height: min-content;
-    max-height: 85%;
+  .lists-wrapper {
+    height: 100%;
+    max-height: 100%;
   }
 
   .list-wrapper {


### PR DESCRIPTION
**What's changed**
- As the title states, when there is multiple lists such that you have to scroll horizontally, if you were to refresh, the app would load and set the scroll to a random position. This has been updated to be set to the beginning
- The horizontal scrollbar is also visible now as it can be confusing if you don't know to scroll
- The lists wrapper div has had it's height updated to 100% to ensure the scrollbar is always at the bottom of the screen
  - Issue #89 has been created to better style these

**Steps to test:**
1. Pull this branch, load the app, and create multiple lists
2. Confirm that you now see the scrollbar at the bottom of your screen to scroll to lists
3. Confirm when you refresh, the app loads with the horizontal scroll set at the start