### PR TITLE
Added support for import/export of tags

### DIFF
--- a/src/components/BoardOptionsMenu/BoardOptionsMenu.tsx
+++ b/src/components/BoardOptionsMenu/BoardOptionsMenu.tsx
@@ -104,18 +104,12 @@ const BoardOptionsMenu = () => {
 
   const handleImportAll = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      console.log("hit");
-
       const file = e.target.files[0];
       let result: ImportData;
       const fr = new FileReader();
       fr.onload = () => {
         const uploadedFileJson = fr.result as string;
-        console.log("hitt");
-
         if (uploadedFileJson) {
-          console.log("hittt");
-
           result = JSON.parse(uploadedFileJson);
           dispatch(deleteAllLists());
           dispatch(deleteAllCards());

--- a/src/components/BoardOptionsMenu/BoardOptionsMenu.tsx
+++ b/src/components/BoardOptionsMenu/BoardOptionsMenu.tsx
@@ -21,12 +21,14 @@ import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { TabIdentifier } from "../../types/global/TabIdentifier";
 import { ExportDataFull, ExportDataList } from "../../types/global/ExportData";
 import ImportData from "../../types/global/ImportData";
+import { updateAllTags } from "../../features/tagsSlice";
 
 const BoardOptionsMenu = () => {
   const dispatch = useAppDispatch();
   const board = useAppSelector((state) => state.board.value);
   const lists = useAppSelector((state) => state.lists.value);
   const cards = useAppSelector((state) => state.cards.value);
+  const tags = useAppSelector((state) => state.tags.value);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const coloursRef = useRef<HTMLButtonElement>(null);
@@ -102,22 +104,30 @@ const BoardOptionsMenu = () => {
 
   const handleImportAll = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
+      console.log("hit");
+
       const file = e.target.files[0];
       let result: ImportData;
       const fr = new FileReader();
       fr.onload = () => {
         const uploadedFileJson = fr.result as string;
+        console.log("hitt");
+
         if (uploadedFileJson) {
+          console.log("hittt");
+
           result = JSON.parse(uploadedFileJson);
           dispatch(deleteAllLists());
           dispatch(deleteAllCards());
           dispatch(updateTitle(result.board.title));
           dispatch(updateAllLists(result.lists));
           dispatch(updateAllCards(result.cards));
-          // TODO add import for tags
+          dispatch(updateAllTags(result.tags));
+          // TODO add import for attachments
         }
-        fr.readAsText(file);
       };
+
+      fr.readAsText(file);
     }
   };
 
@@ -131,6 +141,7 @@ const BoardOptionsMenu = () => {
       board,
       lists: [...lists],
       cards: [...cards],
+      tags: [...tags],
     };
 
     initiateDownload(data);
@@ -143,6 +154,7 @@ const BoardOptionsMenu = () => {
         const data = {
           list,
           cards: cards.filter((card) => card.listId === listId),
+          tags: [...tags],
         };
 
         initiateDownload(data);

--- a/src/features/tagsSlice.ts
+++ b/src/features/tagsSlice.ts
@@ -1,3 +1,4 @@
+import { UpdateAllTagsParams } from "./../types/reducers/TagsSlice";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { v4 as uuidv4 } from "uuid";
 import Tag from "../types/global/Tag";
@@ -31,8 +32,12 @@ export const tagsSlice = createSlice({
       state.value = state.value.filter((tag) => tag.id !== action.payload);
       localStorage.setItem("tags", JSON.stringify([...state.value]));
     },
+    updateAllTags: (state: TagsState, action: PayloadAction<UpdateAllTagsParams>) => {
+      state.value = [...action.payload];
+      localStorage.setItem("tags", JSON.stringify([...state.value]));
+    },
   },
 });
 
-export const { createTag, updateTag, deleteTag } = tagsSlice.actions;
+export const { createTag, updateTag, deleteTag, updateAllTags } = tagsSlice.actions;
 export default tagsSlice.reducer;

--- a/src/types/global/ExportData.ts
+++ b/src/types/global/ExportData.ts
@@ -1,16 +1,19 @@
 import Board from "./Board";
 import Card from "./Card";
 import List from "./List";
+import Tag from "./Tag";
 
 interface ExportData {
   board: Board;
   lists: List[];
   cards: Card[];
+  tags: Tag[];
 }
 
 export type ExportDataFull = ExportData;
 
 export interface ExportDataList {
   list: List;
-  cards: Card[]
+  cards: Card[];
+  tags: Tag[];
 }

--- a/src/types/global/ImportData.ts
+++ b/src/types/global/ImportData.ts
@@ -1,9 +1,11 @@
 import Board from "./Board";
 import Card from "./Card";
 import List from "./List";
+import Tag from "./Tag";
 
 export default interface ImportData {
-  board: Board,
-  cards: Card[],
-  lists: List[],
+  board: Board;
+  cards: Card[];
+  lists: List[];
+  tags: Tag[];
 }

--- a/src/types/reducers/TagsSlice.ts
+++ b/src/types/reducers/TagsSlice.ts
@@ -9,3 +9,5 @@ export type CreateTagParams = Omit<Tag, "id">;
 export type UpdateTagParams = Tag;
 
 export type DeleteTagParams = string;
+
+export type UpdateAllTagsParams = Tag[];


### PR DESCRIPTION
Resolves #161 

I've added the support to import/export tags in json. I created a board for myself but found this was missing when i exported so I've added it.

To test:
- Create a list, then a card
- Open the card, and create a tag, and add a tag to the card
- In the top right, Click Options and Export All. Save this somewhere
- Delete the board
- Import All and choose the file you just exported
- Confirm the card is present with its tag