### PR TITLE
Added description indicator icon

### DIFF
--- a/src/components/List/ListCard/ListCard.tsx
+++ b/src/components/List/ListCard/ListCard.tsx
@@ -2,15 +2,16 @@ import { Draggable } from "react-beautiful-dnd";
 import { setCurrentSelectedCard } from "../../../features/currentSelectedCardSlice";
 import ListCardTag from "./ListCardTag/ListCardTag";
 import { NO_COLOUR } from "../../../constants/TagColours";
-import { AiOutlinePaperClip } from "react-icons/ai";
 import { ListCardProps } from "../../../types/components/ListCardProps";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";
+import ListCardIcons from "./ListCardIcons/ListCardIcons";
 
 const ListCard = ({ card, index }: ListCardProps) => {
   const dispatch = useAppDispatch();
   const tagsToShow = useAppSelector((state) => state.tags.value).filter(
     (tag) => card.tags.includes(tag.id) && tag.colour !== NO_COLOUR
   );
+  const showIcons = card.attachments.length > 0 || card.description.length > 0;
 
   const openModal = () => {
     dispatch(setCurrentSelectedCard(card));
@@ -29,12 +30,7 @@ const ListCard = ({ card, index }: ListCardProps) => {
                 ))}
               </div>
             )}
-            {card.attachments.length > 0 && (
-              <div className="flex items-center text-gray-600 pt-2">
-                <AiOutlinePaperClip />
-                <span className="text-xs pl-1">{card.attachments.length}</span>
-              </div>
-            )}
+            {showIcons && <ListCardIcons card={card} />}
           </div>
         </div>
       )}

--- a/src/components/List/ListCard/ListCardIcons/ListCardIcons.tsx
+++ b/src/components/List/ListCard/ListCardIcons/ListCardIcons.tsx
@@ -1,0 +1,19 @@
+import { AiOutlinePaperClip } from "react-icons/ai";
+import { GrTextAlignFull } from "react-icons/gr";
+import { ListCardIconProps } from "../../../../types/components/ListCardIconProps";
+
+const ListCardIcons = ({ card }: ListCardIconProps) => {
+  return (
+    <div className="flex items-center space-x-2 text-gray-600 pt-2">
+      {card.description.length > 0 && <GrTextAlignFull />}
+      {card.attachments.length > 0 && (
+        <div className="flex justify-center">
+          <AiOutlinePaperClip size={20} />
+          <span className="text-sm">{card.attachments.length}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ListCardIcons;

--- a/src/types/components/ListCardIconProps.ts
+++ b/src/types/components/ListCardIconProps.ts
@@ -1,0 +1,5 @@
+import Card from "../global/Card";
+
+export type ListCardIconProps = {
+  card: Card;
+};


### PR DESCRIPTION
Resolves #136 

Added an icon indicator for description, like attachments i.e.
![image](https://user-images.githubusercontent.com/43914992/175374975-1fc7c4e8-76e0-4e06-be02-e9040b5cd861.png)

How it looks with attachments as well:
![image](https://user-images.githubusercontent.com/43914992/175375030-4cdcf2a5-157e-4491-9745-d34720802573.png)

How to test:
- Create a list, then create a card
- Add a description to the card and confirm when you close the modal, the card has a description indicator as shown in the screenshots