### PR TITLE
Moved CreateTagMenu up into the same div as TagsMenu

### DIFF
--- a/src/components/CardModal/CardModalActions/CardModalActions.tsx
+++ b/src/components/CardModal/CardModalActions/CardModalActions.tsx
@@ -57,8 +57,8 @@ const CardModalActions = () => {
           <p>Tags</p>
         </button>
         {tagsMenuOpen && <TagsMenu />}
+        {createTagsMenuOpen && <CreateTagMenu />}
       </div>
-      {createTagsMenuOpen && <CreateTagMenu />}
       <h4 className="text-gray-800 text-sm">Actions</h4>
       <div className="flex-col flex">
         <button

--- a/src/components/CardModal/CardModalActions/TagsMenu/CreateTagMenu/CreateTagMenu.tsx
+++ b/src/components/CardModal/CardModalActions/TagsMenu/CreateTagMenu/CreateTagMenu.tsx
@@ -79,8 +79,7 @@ const CreateTagMenu = () => {
   };
 
   return (
-    // TODO mt-16 should be replaced with something more robust
-    <div className="fixed mt-16 w-72 min-h-40 text-gray-700 bg-white rounded-ibsm shadow-2xl p-4 ">
+    <div className="fixed mt-10 w-72 min-h-40 text-gray-700 bg-white rounded-ibsm shadow-2xl p-4 ">
       <div className="relative text-center mb-2">
         <span className="text-sm block relative z-10">{titleText}</span>
         <MdArrowBack onClick={handleBack} size={20} className="absolute left-0 top-0 z-20 cursor-pointer" />


### PR DESCRIPTION
Resolves #146 

Similar to the fix for the tags menu positioning you found with flex-col, I've moved CreateTagMenu into the same div and can confirm the positioning behaves like the tags menu

To test:
- Create a list, then create a card. Click on the card
- Click the Tags button, and pay attention to the positioning of the menu. Specifically how it is under the button
- Click Create a new tag and confirm the modal does not change position from under the button (it gets larger, but the top of the menu does not move)