### PR TITLE
Moved Collapse into its own component

### DIFF
--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -1,0 +1,20 @@
+import { useRef } from "react";
+import { CollapseProps } from "../../types/components/CollapseProps";
+
+const Collapse = ({ isOpen, children, className }: CollapseProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const inlineStyle = isOpen ? { height: "100%" } : { height: 0, width: 0 };
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden={!isOpen}
+      style={inlineStyle}
+      className={"transition-height ease overflow-hidden duration-500 " + className}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Collapse;

--- a/src/components/List/AddList/AddList.tsx
+++ b/src/components/List/AddList/AddList.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent, ReactNode } from "react";
+import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent } from "react";
 import { FiPlus, FiX } from "react-icons/fi";
 import { addList } from "../../../features/listsSlice";
 import { useAppDispatch } from "../../../app/hooks";
+import Collapse from "../../Collapse/Collapse";
 
 const AddList = () => {
   const dispatch = useAppDispatch();
@@ -85,25 +86,3 @@ const AddList = () => {
 };
 
 export default AddList;
-
-const Collapse = ({ isOpen, children, className }: CollapseProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const inlineStyle = isOpen ? { height: "100%" } : { height: 0, width: 0 };
-
-  return (
-    <div
-      ref={ref}
-      aria-hidden={!isOpen}
-      style={inlineStyle}
-      className={"transition-height ease overflow-hidden duration-100 " + className}
-    >
-      {children}
-    </div>
-  );
-};
-
-interface CollapseProps {
-  isOpen: boolean;
-  children: ReactNode;
-  className?: string;
-}

--- a/src/types/components/CollapseProps.ts
+++ b/src/types/components/CollapseProps.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export type CollapseProps = {
+  isOpen: boolean;
+  children: ReactNode;
+  className?: string;
+};


### PR DESCRIPTION
Resolved #154 

As the title states, the Collapse component within AddList has been moved into its own component file.

To test:
- Check that adding a list works as expected