### PR TITLE
Updated list options menu style

### DIFF
--- a/src/components/List/ListOptionsMenu/ListOptionsMenu.tsx
+++ b/src/components/List/ListOptionsMenu/ListOptionsMenu.tsx
@@ -3,6 +3,7 @@ import { deleteAllListCards, copyAllCardsToNewList } from "../../../features/car
 import { clearSelectedList } from "../../../features/currentSelectedListSlice";
 import { removeList, copyList } from "../../../features/listsSlice";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";
+import { MdClose } from "react-icons/md";
 
 const ListOptionsMenu = () => {
   const dispatch = useAppDispatch();
@@ -60,15 +61,29 @@ const ListOptionsMenu = () => {
     dispatch(clearSelectedList());
   };
 
+  const handleClose = () => {
+    dispatch(clearSelectedList());
+  };
+
   return (
-    // TODO add a transition for height when this is shown
-    <div ref={ref} style={styles} className="flex flex-col rounded-sm shadow-xl w-24 text-center fixed bg-trello-gray-400">
-      <button className="w-full p-2 cursor-pointer hover:bg-black hover:bg-opacity-20 rounded-md" onClick={handleCopy}>
-        Copy
+    <div
+      ref={ref}
+      style={styles}
+      className="fixed flex flex-col w-72 min-h-40 text-gray-700 bg-white rounded-ibsm shadow-2xl py-2"
+    >
+      <div className="relative text-center mb-2">
+        <span className="mx-auto py-1">List Actions</span>
+        <MdClose onClick={handleClose} size={20} className="absolute right-0 top-0 z-20 cursor-pointer my-1 mr-3" />
+      </div>
+      <hr className="w-11/12 mx-auto" />
+      <button className="w-full text-left px-3 py-2 cursor-pointer hover:bg-black hover:bg-opacity-10" onClick={handleCopy}>
+        Copy list...
       </button>
       {/* TODO remove cursor not allowed when multiple boards have been implemented */}
-      <button className="w-full p-2 cursor-not-allowed opacity-50 hover:bg-black hover:bg-opacity-20 rounded-md">Move</button>
-      <button className="w-full p-2 cursor-pointer hover:bg-black hover:bg-opacity-20 rounded-md" onClick={handleDelete}>
+      <button className="w-full text-left px-3 py-2 cursor-not-allowed opacity-50 hover:bg-black hover:bg-opacity-10">
+        Move
+      </button>
+      <button className="w-full text-left px-3 py-2 cursor-pointer hover:bg-black hover:bg-opacity-10" onClick={handleDelete}>
         Delete
       </button>
     </div>

--- a/src/components/List/ListTitle/ListTitle.tsx
+++ b/src/components/List/ListTitle/ListTitle.tsx
@@ -85,7 +85,7 @@ const ListTitle = ({ list }: ListTitleProps) => {
           {list.title}
         </h2>
       )}
-      <button ref={moreMenuButtonRef} className="hover:bg-trello-gray-500 p-0.5 ml-1.5 rounded-ibsm" onClick={handleMoreMenu}>
+      <button ref={moreMenuButtonRef} className="hover:bg-trello-gray-500 p-1 ml-1.5 rounded-ibsm" onClick={handleMoreMenu}>
         <MdMoreHoriz size={20} className="text-trello-gray-200" />
       </button>
     </div>


### PR DESCRIPTION
Resolves #155 

The below screenshot is of the list options menu in Trello
![image](https://user-images.githubusercontent.com/43914992/176254822-04c824d9-606a-4513-88ff-1404255a6dff.png)

The below screenshot is of the list options menu in our app
![image](https://user-images.githubusercontent.com/43914992/176254929-2ee6c0d4-189d-4e19-a17c-2d74d38d6ca7.png)

Note: Move is disabled as it will be added when multiple boards have been added

To Test:
1. Create a list and click the 3 dot menu. Confirm the menu appears as expected
2. Confirm both copy and delete work as expected
