### PR TITLE
Test code quality touchups

### DIFF
--- a/src/tests/components/CardModal/CardModalActions/CopyMenu/CopyMenu.test.tsx
+++ b/src/tests/components/CardModal/CardModalActions/CopyMenu/CopyMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { RootState } from "../../../../../app/store";
 import CopyMenu from "../../../../../components/CardModal/CardModalActions/CopyMenu/CopyMenu";
 import { renderWithProviders } from "../../../../utils/renderUtils";

--- a/src/tests/components/CardModal/CardModalActions/DeleteMenu/DeleteMenu.test.tsx
+++ b/src/tests/components/CardModal/CardModalActions/DeleteMenu/DeleteMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { RootState } from "../../../../../app/store";
 import DeleteMenu from "../../../../../components/CardModal/CardModalActions/DeleteMenu/DeleteMenu";
 import { renderWithProviders } from "../../../../utils/renderUtils";

--- a/src/tests/components/CardModal/CardModalActions/MoveMenu/MoveMenu.test.tsx
+++ b/src/tests/components/CardModal/CardModalActions/MoveMenu/MoveMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { RootState } from "../../../../../app/store";
 import MoveMenu from "../../../../../components/CardModal/CardModalActions/MoveMenu/MoveMenu";
 import { renderWithProviders } from "../../../../utils/renderUtils";

--- a/src/tests/components/CardModal/CardModalTags/CardModalTag/CardModalTag.test.tsx
+++ b/src/tests/components/CardModal/CardModalTags/CardModalTag/CardModalTag.test.tsx
@@ -1,5 +1,5 @@
+import { render } from "@testing-library/react";
 import CardModalTag from "../../../../../components/CardModal/CardModalTags/CardModalTag/CardModalTag";
-import { renderWithProviders } from "../../../../utils/renderUtils";
 
 describe("CardModalTag", () => {
   it("should render successfully", () => {
@@ -9,7 +9,7 @@ describe("CardModalTag", () => {
       colour: "#FF3244",
     };
 
-    const view = renderWithProviders(<CardModalTag tag={tag} />);
+    const view = render(<CardModalTag tag={tag} />);
     expect(view.asFragment()).toMatchSnapshot();
   });
 });

--- a/src/tests/components/List/ListCard/ListCardTag/ListCardTag.test.tsx
+++ b/src/tests/components/List/ListCard/ListCardTag/ListCardTag.test.tsx
@@ -1,5 +1,5 @@
+import { render } from "@testing-library/react";
 import ListCardTag from "../../../../../components/List/ListCard/ListCardTag/ListCardTag";
-import { renderWithProviders } from "../../../../utils/renderUtils";
 
 describe("ListCardTag", () => {
   it("should render successfully", () => {
@@ -9,7 +9,7 @@ describe("ListCardTag", () => {
       colour: "#FF3244",
     };
 
-    const view = renderWithProviders(<ListCardTag tag={tag} />);
+    const view = render(<ListCardTag tag={tag} />);
     expect(view.asFragment()).toMatchSnapshot();
   });
 });

--- a/src/tests/components/NavBar/NavBar.test.tsx
+++ b/src/tests/components/NavBar/NavBar.test.tsx
@@ -1,9 +1,9 @@
-import { renderWithProviders } from "../../utils/renderUtils";
 import NavBar from "../../../components/NavBar/NavBar";
+import { render } from "@testing-library/react";
 
 describe("NavBar", () => {
   it("should render successfully", () => {
-    const view = renderWithProviders(<NavBar />);
+    const view = render(<NavBar />);
     expect(view.asFragment()).toMatchSnapshot();
   });
 });

--- a/src/tests/components/NavBar/NavBar.test.tsx
+++ b/src/tests/components/NavBar/NavBar.test.tsx
@@ -1,9 +1,9 @@
+import { renderWithProviders } from "../../utils/renderUtils";
 import NavBar from "../../../components/NavBar/NavBar";
-import { render } from "@testing-library/react";
 
 describe("NavBar", () => {
   it("should render successfully", () => {
-    const view = render(<NavBar />);
+    const view = renderWithProviders(<NavBar />);
     expect(view.asFragment()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Just a few minor touchups in this PR i.e.
- Removing unused imports
- Using `render` instead of `renderWithProviders` where appropriate
  - Note: the tests still pass with `renderWithProviders` but as those components don't use any redux bits, `renderWithProviders` isn't necessary and `render` can be used instead

To test:
- Run `yarn test`
- Confirm all tests pass