### PR TITLE
Added GitHub actions build file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: "*"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: yarn install
+    - run: yarn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -26,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: yarn install
+    - run: yarn install --frozen-lockfile 
     - run: yarn test

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap ou
 ### Running tests locally
 
 #### Jest Tests
-
-- Run `yarn test` in the terminal
+- Run `yarn test` to run all tests
+- Run `yarn test --watch` to run the tests in watch mode

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest -c jest.config.js --watch",
+    "test": "jest -c jest.config.js",
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.(ts|tsx)"
   },


### PR DESCRIPTION
Resolves #217 

I've updated the GitHub PRs so that every PR will run the jest tests, and if those tests fail, the PR will be blocked from merging until the tests pass (or we admin override the merge).
This will ensure that situations where failing tests will not be merged, and possibly prevent errors while changing existing functionality

Nothing to test here really. I'll comment the files and just have a look through